### PR TITLE
Fix encoder init

### DIFF
--- a/request.go
+++ b/request.go
@@ -155,7 +155,6 @@ func PackRequest(service Service, header DubboHeader, params interface{}) ([]byt
 		err           error
 		types         string
 		byteArray     []byte
-		encoder       Encoder
 		version       string
 		pkgLen        int
 		serviceParams map[string]string
@@ -182,6 +181,8 @@ func PackRequest(service Service, header DubboHeader, params interface{}) ([]byt
 	byteArray[2] |= byte(header.SerialID & SERIAL_MASK)
 	// request id
 	binary.BigEndian.PutUint64(byteArray[4:], uint64(header.ID))
+
+	encoder := NewEncoder()
 	encoder.Append(byteArray[:HEADER_LENGTH])
 
 	// com.alibaba.dubbo.rpc.protocol.dubbo.DubboCodec.DubboCodec.java line144 encodeRequestData

--- a/request_test.go
+++ b/request_test.go
@@ -37,6 +37,9 @@ func TestPackRequest(t *testing.T) {
 		ID:       123,
 	}, []interface{}{1, 2})
 
-	t.Logf("pack request: %s", string(bytes))
 	assert.Nil(t, err)
+	
+	if bytes != nil {
+		t.Logf("pack request: %s", string(bytes))
+	}
 }

--- a/request_test.go
+++ b/request_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2016 ~ 2019, dubbogo.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hessian
+
+import (
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPackRequest(t *testing.T) {
+	bytes, err := PackRequest(Service{
+		Path:      "/test",
+		Interface: "ITest",
+		Version:   "v1.0",
+		Target:    "test",
+		Method:    "test",
+		Timeout:   time.Second * 10,
+	}, DubboHeader{
+		SerialID: 0,
+		Type:     Request,
+		ID:       123,
+	}, []interface{}{1, 2})
+
+	t.Logf("pack request: %s", string(bytes))
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
fix bug that not initial the encoder in func ParkRequest