### PR TITLE
fix issue https://github.com/dubbogo/hessian2/issues/35

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -133,8 +133,13 @@ func (d *Decoder) decType() (string, error) {
 	return "", err
 }
 
-// Decode parses hessian data
+// Decode parse hessian data, and ensure the reflection value unpacked
 func (d *Decoder) Decode() (interface{}, error) {
+	return EnsureInterface(d.DecodeValue())
+}
+
+// DecodeValue parse hessian data, the return value maybe a reflection value when it's a map, list, object, or ref.
+func (d *Decoder) DecodeValue() (interface{}, error) {
 	var (
 		err error
 		tag byte

--- a/list.go
+++ b/list.go
@@ -47,6 +47,8 @@ func (e *Encoder) encUntypedList(v interface{}) error {
 		return nil
 	}
 
+	value = UnpackPtrValue(value)
+
 	e.buffer = encByte(e.buffer, BC_LIST_FIXED_UNTYPED) // x58
 	e.buffer = encInt32(e.buffer, int32(value.Len()))
 	for i := 0; i < value.Len(); i++ {
@@ -176,7 +178,7 @@ func (d *Decoder) readTypedList(tag byte) (interface{}, error) {
 	holder := d.appendRefs(aryValue)
 
 	for j := 0; j < length || isVariableArr; j++ {
-		it, err := d.Decode()
+		it, err := d.DecodeValue()
 		if err != nil {
 			if err == io.EOF && isVariableArr {
 				break
@@ -228,7 +230,7 @@ func (d *Decoder) readUntypedList(tag byte) (interface{}, error) {
 	holder := d.appendRefs(aryValue)
 
 	for j := 0; j < length || isVariableArr; j++ {
-		it, err := d.Decode()
+		it, err := d.DecodeValue()
 		if err != nil {
 			if err == io.EOF && isVariableArr {
 				continue

--- a/map.go
+++ b/map.go
@@ -196,7 +196,7 @@ func (d *Decoder) decMapByValue(value reflect.Value) error {
 
 	//read key and value
 	for {
-		entryKey, err = d.Decode()
+		entryKey, err = d.DecodeValue()
 		if err != nil {
 			// EOF means the end flag 'Z' of map is already read
 			if err == io.EOF {
@@ -208,11 +208,12 @@ func (d *Decoder) decMapByValue(value reflect.Value) error {
 		if entryKey == nil {
 			break
 		}
-		entryValue, err = d.Decode()
+		entryValue, err = d.DecodeValue()
 		// fix: check error
 		if err != nil {
 			return perrors.WithStack(err)
 		}
+		// TODO map value may be a ref object
 		m.Elem().SetMapIndex(EnsurePackValue(entryKey), EnsurePackValue(entryValue))
 	}
 
@@ -221,6 +222,7 @@ func (d *Decoder) decMapByValue(value reflect.Value) error {
 	return nil
 }
 
+// TODO to decode ref object in map
 func (d *Decoder) decMap(flag int32) (interface{}, error) {
 	var (
 		err        error

--- a/object.go
+++ b/object.go
@@ -344,7 +344,7 @@ func (d *Decoder) decInstance(typ reflect.Type, cls classInfo) (interface{}, err
 				// java enum
 				if fldRawValue.Type().Implements(javaEnumType) {
 					d.unreadByte() // Enum parsing, decInt64 above has read a byte, so you need to return a byte here
-					s, err := d.Decode()
+					s, err := d.DecodeValue()
 					if err != nil {
 						return nil, perrors.Wrapf(err, "decInstance->decObject field name:%s", fieldName)
 					}
@@ -515,7 +515,7 @@ func (d *Decoder) decObject(flag int32) (interface{}, error) {
 		//add to slice
 		d.appendClsDef(cls)
 
-		return d.Decode()
+		return d.DecodeValue()
 
 	case tag == BC_OBJECT:
 		idx, err = d.decInt32(TAG_READ)

--- a/response.go
+++ b/response.go
@@ -202,6 +202,7 @@ func CopyMap(inMapValue, outMapValue reflect.Value) error {
 }
 
 // ReflectResponse reflect return value
+// TODO response object should not be copied again to another object, it should be the exact type of the object
 func ReflectResponse(in interface{}, out interface{}) error {
 	if in == nil {
 		return perrors.Errorf("@in is nil")


### PR DESCRIPTION
fix issue #35 to support hessian array response.

Notice:
1. now, list&map feature are not completed, the enhancement of which is added into [todo list](https://github.com/dubbogo/hessian2/wiki)
2. hessian codec cares about encode/decode, while dubbo request/response should not.